### PR TITLE
Add init modules and clean hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,24 +1,11 @@
 repos:
   - repo: https://github.com/astral-sh/uv-pre-commit
-    # uv version.
     rev: 0.5.14
     hooks:
       - id: uv-lock
-    # - repo: https://github.com/psf/black
-    # rev: 24.4.2
-    # hooks:
-    # - id: black
-    # args: ["--quiet"]
-    # - repo: https://github.com/pycqa/isort
-    # rev: 5.13.2
-    # hooks:
-    # - id: isort
-    # args: ["--profile", "black"]
-    # Ruff version.
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.8.6
     hooks:
-      # Run the linter.
       - id: ruff
         args: [--fix]
       - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -84,10 +84,20 @@ uv sync --dev
 uvx pre-commit install
 ```
 
+Formatting and linting are handled by [Ruff](https://docs.astral.sh/ruff/), so
+the repository no longer includes Black or Isort hooks.
+
+Unit tests can be run with `pytest`:
+
+```bash
+pytest
+```
+
 ## Directory Structure
 
 - `main.py` – example entry point for running environments.
-- `tag/` – Python package with experimental code (e.g. `brax/barkour.py`).
+- `tag/` – Python package with experimental code (e.g. `brax/barkour.py`). The
+  directory now includes `__init__.py` files so modules can be imported.
 - `extras/` – additional resources used in notebooks or experiments.
 - `third-party/` – vendored dependencies or assets.
 - `pyproject.toml` – project configuration and dependency list.

--- a/tag/__init__.py
+++ b/tag/__init__.py
@@ -1,0 +1,1 @@
+"""Robotics experiments and utilities package."""

--- a/tag/brax/__init__.py
+++ b/tag/brax/__init__.py
@@ -1,0 +1,1 @@
+"""Brax environment experiments."""

--- a/tag/gen/__init__.py
+++ b/tag/gen/__init__.py
@@ -1,0 +1,1 @@
+"""Genesis-based environment utilities."""

--- a/tag/gym/__init__.py
+++ b/tag/gym/__init__.py
@@ -1,0 +1,1 @@
+"""Gym-style robotics environments."""

--- a/tag/gym/base/__init__.py
+++ b/tag/gym/base/__init__.py
@@ -1,0 +1,1 @@
+"""Base environment definitions."""

--- a/test/test_imports.py
+++ b/test/test_imports.py
@@ -1,0 +1,12 @@
+import importlib
+
+
+def test_package_importable():
+    tag = importlib.import_module("tag")
+    assert hasattr(tag, "__path__")
+
+
+def test_subpackages_importable():
+    for name in ["tag.brax", "tag.gen", "tag.gym", "tag.gym.base"]:
+        module = importlib.import_module(name)
+        assert module.__name__ == name


### PR DESCRIPTION
## Summary
- add `__init__` files so the `tag` package is importable
- clean out old Black/Isort hooks from pre-commit config
- update development docs on Ruff and running tests
- basic tests ensure subpackages import correctly

## Testing
- `ruff check .`
- `pytest -q test/test_imports.py` *(fails: command not found)*