### PR TITLE
Refactor chase env and add terrain mixin

### DIFF
--- a/tag/gym/envs/chase/utils.py
+++ b/tag/gym/envs/chase/utils.py
@@ -1,0 +1,44 @@
+"""Helper utilities for the chase environment."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import genesis as gs
+
+from .chase_config import ChaseEnvConfig
+from tag.gym.robots.multi import MultiRobot
+from tag.gym.robots.go2 import Go2Config
+
+
+def create_scene(cfg: ChaseEnvConfig, n_rendered: int) -> gs.Scene:
+    """Return a Genesis scene configured from ``cfg``."""
+    return gs.Scene(
+        show_viewer=cfg.viewer.show_viewer,
+        rigid_options=gs.options.RigidOptions(
+            enable_joint_limit=cfg.solver.joint_limit,
+            dt=cfg.solver.dt,
+        ),
+        vis_options=gs.options.VisOptions(
+            show_world_frame=cfg.vis.show_world_frame,
+            n_rendered_envs=n_rendered,
+        ),
+    )
+
+
+def create_robots(scene: gs.Scene, cfg: Go2Config) -> MultiRobot:
+    """Instantiate the pair of Go2 robots for the chase task."""
+    return MultiRobot(scene, cfg, ["r1", "r2"])
+
+
+def create_camera(scene: gs.Scene, enabled: bool) -> Optional[gs.Camera]:
+    """Add a default camera if ``enabled`` is ``True``."""
+    if not enabled:
+        return None
+    return scene.add_camera(
+        res=(1280, 720),
+        pos=(7, 0.0, 2.5),
+        lookat=(0, 0, 0.5),
+        fov=60,
+        GUI=False,
+    )

--- a/tag/gym/envs/terrain_mixin.py
+++ b/tag/gym/envs/terrain_mixin.py
@@ -1,0 +1,20 @@
+"""Utility mixin for adding terrain support to environments."""
+
+import genesis as gs
+
+class TerrainEnvMixin:
+    """Mixin to add terrain creation helpers for environments."""
+
+    def build_terrain(self) -> None:
+        """Create terrain entity based on ``self.cfg.terrain``.
+
+        Subclasses are expected to define ``self.scene`` and ``self.cfg`` with a
+        ``terrain`` attribute specifying the mesh type.
+        """
+        mesh_type = getattr(self.cfg.terrain, "mesh_type", "plane")
+        if mesh_type == "plane":
+            self.terrain = self.scene.add_entity(gs.morphs.Plane())
+        elif mesh_type == "heightfield":
+            self.terrain = self.scene.add_entity(gs.morphs.Terrain())
+        else:
+            raise ValueError(f"Unsupported terrain mesh type: {mesh_type}")

--- a/test/test_terrain.py
+++ b/test/test_terrain.py
@@ -1,0 +1,83 @@
+from types import SimpleNamespace
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Provide a stub genesis module so imports succeed without the heavy dependency.
+sys.modules.setdefault(
+    "genesis",
+    SimpleNamespace(
+        morphs=SimpleNamespace(Plane=object, Terrain=object),
+        options=SimpleNamespace(RigidOptions=object, VisOptions=object),
+        Scene=object,
+    ),
+)
+sys.modules.setdefault("numpy", SimpleNamespace())
+sys.modules.setdefault("torch", SimpleNamespace())
+sys.modules.setdefault("tag.gym.robots.go2", SimpleNamespace(Go2Config=object, Go2Robot=object))
+
+from tag.gym.envs import terrain_mixin
+from tag.gym.envs.terrain_mixin import TerrainEnvMixin
+from tag.gym.envs.chase.utils import create_scene
+from tag.gym.envs.chase.chase_config import ChaseEnvConfig
+
+
+class DummyScene:
+    def __init__(self):
+        self.entities = []
+
+    def add_entity(self, entity):
+        self.entities.append(entity)
+        return entity
+
+
+class DummyEnv(TerrainEnvMixin):
+    def __init__(self, mesh_type: str):
+        self.scene = DummyScene()
+        self.cfg = SimpleNamespace(terrain=SimpleNamespace(mesh_type=mesh_type))
+
+
+def test_build_terrain_plane(monkeypatch):
+    """Ensure the mixin adds a plane when requested."""
+    Plane = type("Plane", (), {})
+    Terrain = type("Terrain", (), {})
+    stub_gs = SimpleNamespace(morphs=SimpleNamespace(Plane=Plane, Terrain=Terrain))
+    monkeypatch.setattr(terrain_mixin, "gs", stub_gs)
+
+    env = DummyEnv("plane")
+    env.build_terrain()
+
+    assert isinstance(env.scene.entities[0], Plane)
+
+
+def test_create_scene(monkeypatch):
+    """create_scene should forward options to the stub Scene class."""
+    calls = {}
+
+    class Scene:
+        def __init__(self, **kwargs):
+            calls.update(kwargs)
+
+    class RigidOptions:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class VisOptions:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    stub_gs = SimpleNamespace(
+        Scene=Scene,
+        options=SimpleNamespace(RigidOptions=RigidOptions, VisOptions=VisOptions),
+    )
+    import tag.gym.envs.chase.utils as utils
+    monkeypatch.setattr(utils, "gs", stub_gs)
+
+    cfg = ChaseEnvConfig()
+    scene = create_scene(cfg, 3)
+
+    assert isinstance(scene, Scene)
+    assert calls["vis_options"].kwargs["n_rendered_envs"] == 3


### PR DESCRIPTION
## Summary
- introduce `TerrainEnvMixin` for simple terrain creation
- refactor chase environment to use helper utilities
- extract camera/scene helpers into `utils.py`
- document code with type hints
- add unit tests for terrain mixin and utilities

## Testing
- `pytest -q`