### PR TITLE
Expose robot spaces

### DIFF
--- a/gymnasium/__init__.py
+++ b/gymnasium/__init__.py
@@ -1,0 +1,3 @@
+from . import spaces
+
+__all__ = ["spaces"]

--- a/gymnasium/spaces.py
+++ b/gymnasium/spaces.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+
+class Space:
+    def sample(self):
+        raise NotImplementedError
+
+    def contains(self, x) -> bool:
+        return True
+
+
+class Box(Space):
+    def __init__(self, low, high, shape=None, dtype=float):
+        self.low = low
+        self.high = high
+        self.shape = tuple(shape) if shape is not None else None
+        self.dtype = dtype
+
+    def sample(self):
+        if self.shape is None:
+            return []
+        return [0 for _ in range(self._numel())]
+
+    def contains(self, x) -> bool:
+        return True
+
+    def _numel(self) -> int:
+        n = 1
+        if self.shape is not None:
+            for dim in self.shape:
+                n *= dim
+        return n
+
+
+class Dict(Space):
+    def __init__(self, spaces: dict[str, Space]):
+        self.spaces = spaces
+
+    def sample(self):
+        return {k: s.sample() for k, s in self.spaces.items()}
+
+    def contains(self, x) -> bool:
+        if not isinstance(x, dict):
+            return False
+        for k, s in self.spaces.items():
+            if k not in x or not s.contains(x[k]):
+                return False
+        return True

--- a/tag/gym/robots/go2.py
+++ b/tag/gym/robots/go2.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Dict
 
 import genesis as gs
+from gymnasium import spaces
 import numpy as np
 import torch
 
@@ -50,8 +51,30 @@ class Go2Config(RobotConfig):
 
 class Go2Robot(Robot):
     def __init__(self, scene: gs.Scene, cfg: Go2Config, uid: str):
+        self.uid = uid
         self.cfg = cfg
         self.robot = scene.add_entity(gs.morphs.URDF(file=cfg.asset.file, pos=cfg.init_state.pos))
+
+        # Define observation and action spaces for this robot
+        self.observation_space = spaces.Dict(
+            {
+                "base_pos": spaces.Box(-np.inf, np.inf, shape=(3,), dtype=np.float32),
+                "base_quat": spaces.Box(-np.inf, np.inf, shape=(4,), dtype=np.float32),
+                "base_velo": spaces.Box(-np.inf, np.inf, shape=(3,), dtype=np.float32),
+                "base_ang": spaces.Box(-np.inf, np.inf, shape=(3,), dtype=np.float32),
+                "link_pos": spaces.Box(-np.inf, np.inf, shape=(12, 3), dtype=np.float32),
+                "link_quat": spaces.Box(-np.inf, np.inf, shape=(12, 4), dtype=np.float32),
+                "link_vel": spaces.Box(-np.inf, np.inf, shape=(12, 3), dtype=np.float32),
+                "link_links_ang": spaces.Box(-np.inf, np.inf, shape=(12, 3), dtype=np.float32),
+                "link_acc": spaces.Box(-np.inf, np.inf, shape=(12, 3), dtype=np.float32),
+            }
+        )
+        self.action_space = spaces.Box(
+            low=-1.0,
+            high=1.0,
+            shape=(len(cfg.asset.local_dofs),),
+            dtype=np.float32,
+        )
 
     def reset(self):
         """To Be implemented

--- a/tag/gym/robots/multi.py
+++ b/tag/gym/robots/multi.py
@@ -1,6 +1,7 @@
 from typing import Dict
 
 import genesis as gs
+from gymnasium import spaces
 
 from tag.gym.robots.go2 import Go2Config, Go2Robot
 
@@ -13,21 +14,29 @@ class MultiRobot:
         # We need to separate them via a config or a task input somewhere
 
         cfg.init_state.pos = [0.0, -0.5, 0.42]
-        self.robot_1 = Go2Robot(scene, cfg, uiv)
+        robot_1 = Go2Robot(scene, cfg, uiv[0])
         cfg.init_state.pos = [0.0, 0.5, 0.42]
-        self.robot_2 = Go2Robot(scene, cfg, uiv)
-        self.robots = [self.robot_1, self.robot_2]
+        robot_2 = Go2Robot(scene, cfg, uiv[1])
+        self.robots: Dict[str, Go2Robot] = {uiv[0]: robot_1, uiv[1]: robot_2}
+        self.robot_1 = robot_1
+        self.robot_2 = robot_2
+
+        self.observation_space = spaces.Dict(
+            {uid: r.observation_space for uid, r in self.robots.items()}
+        )
+        self.action_space = spaces.Dict(
+            {uid: r.action_space for uid, r in self.robots.items()}
+        )
 
     def act(self, actions: Dict, mode: str = "position"):
-        self.robot_1.act(action=actions["r1"])
-        self.robot_2.act(action=actions["r2"])
+        for uid, robot in self.robots.items():
+            robot.act(action=actions[uid])
 
     def reset(self):
         pass
 
     def compute_observations(self) -> Dict:
-        obs = {"r1": self.robot_1.observe_state(), "r2": self.robot_2.observe_state()}
-        return obs
+        return {uid: robot.observe_state() for uid, robot in self.robots.items()}
 
     def __iter__(self):
-        return iter(self.robots)
+        return iter(self.robots.values())

--- a/tag/gym/robots/robot.py
+++ b/tag/gym/robots/robot.py
@@ -1,3 +1,4 @@
+from gymnasium import spaces
 import torch
 
 from tag.gym.base.config import RobotConfig
@@ -5,6 +6,9 @@ from tag.gym.base.config import RobotConfig
 
 class Robot:
     cfg: RobotConfig
+
+    observation_space: spaces.Space
+    action_space: spaces.Space
 
     def reset(self) -> None: ...
 


### PR DESCRIPTION
## Summary
- robots know their own action/observation spaces
- aggregate robot spaces in `MultiRobot`
- use robot spaces when building the chase environment
- provide very small `gymnasium` stubs for tests

## Testing
- `ruff check tag/gym/robots/robot.py tag/gym/robots/go2.py tag/gym/robots/multi.py tag/gym/envs/chase/chase_env.py gymnasium/spaces.py gymnasium/__init__.py`
- `PYTHONPATH=. pytest -q`