### PR TITLE
Delegate chase env buffers to BaseEnv

### DIFF
--- a/tag/gym/base/env.py
+++ b/tag/gym/base/env.py
@@ -1,9 +1,10 @@
 from abc import abstractmethod
 from typing import Dict, Tuple, Union
 
+import genesis as gs
 import torch
 
-from tag.gym.base.config import EnvConfig
+from tag.gym.base.config import EnvConfig, Task
 
 # TODO add somewhere
 # num_privileged_obs: int
@@ -13,7 +14,20 @@ from tag.gym.base.config import EnvConfig
 
 class BaseEnv:
     def __init__(self, args=None, cfg: EnvConfig = EnvConfig()):
-        pass
+        """Initialize common environment attributes."""
+
+        self.cfg: EnvConfig = cfg
+        self.device = gs.gpu
+        self.n_envs = cfg.sim.num_envs
+        self.n_rendered = cfg.vis.n_rendered_envs
+        self.env_spacing = tuple(cfg.vis.env_spacing)
+
+        task_cfg = getattr(cfg, "task", Task())
+        self.num_obs = task_cfg.num_obs
+        self.num_privileged_obs = task_cfg.num_privileged_obs
+        self.max_episode_length = task_cfg.max_episode_length
+
+        self._init_buffers()
 
     def build(self) -> None:
         ...
@@ -22,6 +36,56 @@ class BaseEnv:
     def step(self, actions: torch.Tensor) -> None: ...
 
     def reset(self) -> None: ...
+
+    def record_data(self) -> None:
+        """Finalize and save camera recordings, if any."""
+        if getattr(self.cfg.vis, "visualized", False) and hasattr(self, "cam"):
+            self.cam.stop_recording(
+                save_to_filename="./tag/gym/mp4/tagV1_video.mp4", fps=60
+            )
+
+    def _init_buffers(self) -> None:
+        """Allocate common buffers used for stepping the environment."""
+        self.obs_buf = torch.zeros(
+            (self.n_envs, self.num_obs), device=self.device, dtype=gs.tc_float
+        )
+        self.privileged_obs_buf = (
+            None
+            if self.num_privileged_obs is None
+            else torch.zeros(
+                (self.n_envs, self.num_privileged_obs),
+                device=self.device,
+                dtype=gs.tc_float,
+            )
+        )
+        self.reset_buf = torch.ones(
+            (self.n_envs,), device=self.device, dtype=gs.tc_int
+        )
+        self.rew_buf = torch.zeros(
+            (self.n_envs,), device=self.device, dtype=gs.tc_float
+        )
+        self.episode_length_buf = torch.zeros(
+            (self.n_envs,), device=self.device, dtype=gs.tc_int
+        )
+
+    def _update_buffers(self) -> None:
+        """Placeholder buffer update used for testing."""
+        self.episode_length_buf += 1
+        self.obs_buf = torch.cat(
+            [
+                torch.cat(
+                    [
+                        torch.rand(4),
+                        torch.rand(4),
+                    ]
+                )
+            ]
+        )
+        self.rew_buf[:] = 0.0
+        values = [i for i in range(len(self.rew_buf))]
+        for i in range(len(values)):
+            rew = values[i]
+            self.rew_buf += rew
 
     @abstractmethod
     def get_observations(self) -> Tuple[torch.Tensor, Dict]: ...

--- a/tag/gym/envs/chase/chase_env.py
+++ b/tag/gym/envs/chase/chase_env.py
@@ -19,23 +19,11 @@ class Chase(TerrainEnvMixin, BaseEnv):
 
     def __init__(self, args: Dict | None = None, cfg: ChaseEnvConfig = ChaseEnvConfig()):
         """Create a new environment instance."""
+        super().__init__(args, cfg)
         self.cfg: ChaseEnvConfig = cfg
-        # if args is not None:
-        #     self.n_envs = args.n_envs
-        #     self.n_rendered = args.n_rendered
-        #     self.n_envs = args.n_envs
-        #     self.n_rendered = args.n_rendered
-        # else:
-        #     self.n_envs = self.cfg.sim.num_envs
-        #     self.n_rendered = self.cfg.vis.n_rendered_envs
         self.n_envs = 4
         self.n_rendered = 4
         self.env_spacing = (2.5, 2.5)
-        self.device = gs.gpu  # CPU Support maybe?
-        # self.episode_length = self.cfg.sim.episode_length
-        # self.num_obs = self.cfg.sim.num_obs
-        # self.num_privileged_obs = self.cfg.sim.num_privileged_obs
-        # self.max_episode_length = self.cfg.sim.max_episode_length
 
         # Init
         gs.init(
@@ -46,7 +34,6 @@ class Chase(TerrainEnvMixin, BaseEnv):
         # Scene
         self.scene: gs.Scene = create_scene(cfg, self.n_rendered)
 
-        # self._init_buffers()
         self._init_spaces()
 
         # Entities
@@ -77,8 +64,6 @@ class Chase(TerrainEnvMixin, BaseEnv):
 
         self.scene.step()
 
-        # Update Buffers - Implented for Testing
-        # self._update_buffers()
         # Check termination and reset
         # Compute weward
         # Compute observations
@@ -129,30 +114,6 @@ class Chase(TerrainEnvMixin, BaseEnv):
         self._obs = obs
         return self.get_observations()
 
-    def record_data(self):
-        """Finalize and save any visual recordings."""
-        if self.cfg.vis.visualized:
-            self.cam.stop_recording(save_to_filename="./tag/gym/mp4/tagV1_video.mp4", fps=60)
-
-    def _init_buffers(self):
-        """Allocate internal tensors used for stepping the environment."""
-        self.obs_buf = torch.zeros((self.n_envs, self.num_obs), device=self.device, dtype=gs.tc_float)
-        self.privileged_obs_buf = (
-            None
-            if self.num_privileged_obs is None
-            else torch.zeros(
-                (self.n_envs, self.num_privileged_obs),
-                device=self.device,
-                dtype=gs.tc_float,
-            )
-        )
-        self.reset_buf = torch.ones((self.n_envs,), device=self.device, dtype=gs.tc_int)
-        self.rew_buf = torch.zeros((self.n_envs,), device=self.device, dtype=gs.tc_float)
-        self.episode_length_buf = torch.zeros((self.n_envs,), device=self.device, dtype=gs.tc_int)
-
-        # TODO: Implement buffer initialization for Go2 Models once Robot class is implemented
-        # self.base_lin_vel = torch.zeros((self.n_envs, 3), device=gs.device, dtype=gs.tc_float)
-        # self.base_ang_vel = torch.zeros((self.n_envs, 3), device=gs.device, dtype=gs.tc_float)
 
     def _init_spaces(self):
         """Define observation and action spaces."""
@@ -200,27 +161,3 @@ class Chase(TerrainEnvMixin, BaseEnv):
             }
         )
 
-    def _update_buffers(self):
-        """Example buffer update for testing."""
-        self.episode_length_buf += 1
-        self.obs_buf = torch.cat(  # Entire Observation
-            [
-                # Robot, Environment, Terrain, etc
-                torch.cat(  # Testing Data for Robot Position
-                    [
-                        torch.rand(4),  # Arb position for Robot 1
-                        torch.rand(4),
-                    ]  # Arb position for Robot 2
-                )
-            ]
-        )
-
-        # TODO: Implement Reset Check
-        # Fake Reward Step
-        self.rew_buf[:] = 0.0
-        values = [i for i in range(len(self.rew_buf))]
-        for i in range(len(values)):
-            rew = values[i]
-            self.rew_buf += rew
-
-    # Silent Todo - Implement Domain Randomization


### PR DESCRIPTION
## Summary
- factor common buffer logic into `BaseEnv`
- call `super().__init__()` in `Chase` environment and remove duplicate methods

## Testing
- `PYTHONPATH=. pytest -q`