### PR TITLE
Add ClipNormWrapper to handle action/obs clipping

### DIFF
--- a/tag/gym/envs/_lr/env.py
+++ b/tag/gym/envs/_lr/env.py
@@ -12,7 +12,6 @@ import torch
 # from legged_gym.utils.helpers import class_to_dict
 # from legged_gym.utils.math import quat_apply_yaw, wrap_to_pi
 # from legged_gym.utils.terrain import Terrain
-
 # from .legged_robot_config import LeggedRobotCfg
 from ..domain_rand_mixin import DomainRandMixin
 
@@ -46,8 +45,7 @@ class LeggedRobot(DomainRandMixin):
         Args:
             actions (torch.Tensor): Tensor of shape (num_envs, num_actions_per_env)
         """
-        clip_actions = self.cfg.normalization.clip_actions
-        self.actions = torch.clip(actions, -clip_actions, clip_actions).to(self.device)
+        self.actions = actions.to(self.device)
         exec_actions = self.last_actions if self.simulate_action_latency else self.actions
         if self.cfg.sim.use_implicit_controller:  # use embedded pd controller
             target_dof_pos = self._compute_target_dof_pos(exec_actions)
@@ -66,11 +64,7 @@ class LeggedRobot(DomainRandMixin):
                 self.dof_vel[:] = self.robot.get_dofs_velocity(self.motor_dofs)
         self.post_physics_step()
 
-        # return clipped obs, clipped states (None), rewards, dones and infos
-        clip_obs = self.cfg.normalization.clip_observations
-        self.obs_buf = torch.clip(self.obs_buf, -clip_obs, clip_obs)
-        if self.privileged_obs_buf is not None:
-            self.privileged_obs_buf = torch.clip(self.privileged_obs_buf, -clip_obs, clip_obs)
+        # return obs, privileged obs, rewards, dones and infos
         return (
             self.obs_buf,
             self.privileged_obs_buf,

--- a/tag/gym/envs/wrappers/clip_norm.py
+++ b/tag/gym/envs/wrappers/clip_norm.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Any, Tuple
+
+import torch
+
+
+class ClipNormWrapper:
+    """Clip actions and observations using ``env.cfg.normalization``."""
+
+    def __init__(self, env):
+        self.env = env
+        norm = getattr(env.cfg, "normalization", None)
+        self.clip_actions = getattr(norm, "clip_actions", None)
+        self.clip_obs = getattr(norm, "clip_observations", None)
+
+    def step(self, actions: torch.Tensor) -> Tuple[Any, ...]:
+        if self.clip_actions is not None:
+            actions = torch.clip(actions, -self.clip_actions, self.clip_actions)
+        obs, p_obs, rew, done, info = self.env.step(actions)
+        if self.clip_obs is not None:
+            obs = torch.clip(obs, -self.clip_obs, self.clip_obs)
+            if p_obs is not None:
+                p_obs = torch.clip(p_obs, -self.clip_obs, self.clip_obs)
+        return obs, p_obs, rew, done, info
+
+    def reset(self, *args, **kwargs):
+        return self.env.reset(*args, **kwargs)
+
+    def __getattr__(self, attr: str):
+        return getattr(self.env, attr)


### PR DESCRIPTION
## Summary
- add ClipNormWrapper so clipping logic stays outside env
- remove clipping code from LeggedRobot.step

## Testing
- `ruff check tag/gym/envs/wrappers/clip_norm.py tag/gym/envs/_lr/env.py --fix`
- `ruff format tag/gym/envs/wrappers/clip_norm.py tag/gym/envs/_lr/env.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'genesis')*