### PR TITLE
Add Unitree H1 robot

### DIFF
--- a/tag/gym/robots/__init__.py
+++ b/tag/gym/robots/__init__.py
@@ -1,6 +1,17 @@
-from .robot import Robot,RobotConfig
-from .go2 import Go2Config,Go2Robot
 from typing import Union
 
-ops = (RobotConfig,Go2Config)
+from .go2 import Go2Config, Go2Robot
+from .h1 import H1Config, H1Robot
+from .robot import Robot, RobotConfig
+
+__all__ = [
+    "Robot",
+    "RobotConfig",
+    "Go2Config",
+    "Go2Robot",
+    "H1Config",
+    "H1Robot",
+]
+
+ops = (RobotConfig, Go2Config, H1Config)
 RobotTyp = Union[*ops]

--- a/tag/gym/robots/go2.py
+++ b/tag/gym/robots/go2.py
@@ -1,6 +1,4 @@
 from dataclasses import dataclass
-from genesis.utils.geom import (inv_quat, quat_to_xyz, transform_by_quat,
-                                transform_quat_by_quat)
 from typing import Dict
 
 import genesis as gs
@@ -111,10 +109,6 @@ class Go2Config(RobotConfig):
         """Create a Go2 robot instance."""
         return Go2Robot(scene, self)
 
-    @property
-    def dof_names(self):
-        return list(self.state.joints.keys())
-
 
 @dataclass
 class PipeState:
@@ -137,15 +131,10 @@ class PipeState:
 
 class Go2Robot(Robot):
     def __init__(self, scene: gs.Scene, cfg: Go2Config):
-        self.cfg = cfg
-        self.robot = self.cfg._create(scene)
+        super().__init__(scene, cfg)
         # self.robot.set_dofs_stiffness(
         # self.robot.set_dofs_damping(
 
-    @property
-    def wrapped(self) -> RigidEntity:
-        """Return the wrapped RigidEntity."""
-        return self.robot
 
     @property
     def action_space(self) -> spaces.Box:
@@ -182,29 +171,6 @@ class Go2Robot(Robot):
         # NOTE(dle): Requires Current Genesis Branch
         # "link_acc": spaces.Box(-np.inf, np.inf, shape=(12, 3), dtype=np.float32),
 
-    def act(self, action: torch.Tensor, mode: str = "position"):
-        # FEATURE: Velocity/Force if needed
-        # NOTE(dle): dofs_idx_local should import from Go2Config, needs to be fixed.
-        if mode == "position":
-            self.robot.control_dofs_position(
-                position=action,
-                dofs_idx_local=self.dofs,
-            )
-
-    @property
-    def pos(self) -> torch.Tensor:
-        """Get the current position of the robot."""
-        return torch.tensor(self.robot.get_pos(), device=gs.device, dtype=gs.tc_float)
-
-    @property
-    def quat(self) -> torch.Tensor:
-        """Get the current orientation (quaternion) of the robot."""
-        return torch.tensor(self.robot.get_quat(), device=gs.device, dtype=gs.tc_float)
-
-    @property
-    def inv_quat(self) -> torch.Tensor:
-        """Get the inverse quaternion of the robot's orientation."""
-        return inv_quat(self.quat)
 
     def observe(self) -> Dict:
         obs = {
@@ -236,14 +202,6 @@ class Go2Robot(Robot):
     def randomize(self, cfg):
         pass
 
-    @property
-    def dofs(self):
-        # NOTE(mhyatt) new genesis API prefers dofs vs dof, which returns list
-        names = sum(
-            [self.robot.get_joint(name).dofs_idx_local for name in self.cfg.dof_names],
-            [],
-        )
-        return names
 
     @property
     def feet(self):
@@ -344,47 +302,4 @@ class Go2Robot(Robot):
         return obs
 
     def reset(self, envs_idx: list[int]):
-        _B = len(envs_idx)
-        if _B == 0:
-            return
-
-        # if state is not None:
-        # raise NotImplementedError("passed arg reset not implemented")
-
-        # TODO joint_pos flattens the joints . make sure the idxs are correct
-        def _batch_tile(item: list[int]):
-            return torch.Tensor(item).tile((_B, 1))
-
-        kp = torch.Tensor([self.cfg.control.kp for _ in range(len(self.dofs))])
-        kd = torch.Tensor([self.cfg.control.kd for _ in range(len(self.dofs))])
-        self.robot.set_dofs_kp(kp, dofs_idx_local=self.dofs)
-        self.robot.set_dofs_kv(kd, dofs_idx_local=self.dofs)
-
-        self.robot.set_dofs_position(
-            # position=self.cfg.state.joints[envs_idx], # certain states
-            position=_batch_tile(list(self.cfg.state.joints.values())),
-            dofs_idx_local=self.dofs,
-            zero_velocity=True,
-            envs_idx=envs_idx,
-        )
-
-        self.robot.set_pos(_batch_tile(self.cfg.state.pos), zero_velocity=False, envs_idx=envs_idx)
-        self.robot.set_quat(_batch_tile(self.cfg.state.quat), zero_velocity=False, envs_idx=envs_idx)
-        self.robot.zero_all_dofs_velocity(envs_idx)
-
-        # reset dofs
-        # self.dof_pos[envs_idx] = self.default_dof_pos
-        # self.dof_vel[envs_idx] = 0.0
-        # reset base
-        # self.base_pos[envs_idx] = self.cfg.state.pos.reshape(1, -1)
-        # self.base_quat[envs_idx] = self.cfg.state.quat.reshape(1, -1)
-        # reset velocity
-        # self.base_lin_vel[envs_idx] = 0
-        # self.base_ang_vel[envs_idx] = 0
-        # reset buffers
-        # self.last_actions[envs_idx] = 0.0
-        # self.last_dof_vel[envs_idx] = 0.0
-        # self.episode_length_buf[envs_idx] = 0
-        # self.reset_buf[envs_idx] = True
-
-        # TODO observe state
+        super().reset(envs_idx)

--- a/tag/gym/robots/h1.py
+++ b/tag/gym/robots/h1.py
@@ -1,0 +1,92 @@
+from dataclasses import dataclass
+from typing import Dict
+
+import genesis as gs
+from genesis.engine.entities.rigid_entity import RigidEntity
+from gymnasium import spaces
+import numpy as np
+import torch
+
+from tag.gym.base.config import MJCF, Control
+from tag.names import MENAGERIE
+from tag.utils import default
+
+from .robot import Robot, RobotConfig, RobotState
+
+H1MJCF = MJCF(file=str(MENAGERIE / "unitree_h1" / "h1.xml"))
+
+
+@dataclass
+class H1State(RobotState):
+    """State for the H1 robot."""
+
+    joints: Dict[str, float] = default({})
+
+    @property
+    def dof_pos(self) -> torch.Tensor:
+        return torch.tensor(list(self.joints.values()), device=gs.device)
+
+
+@dataclass
+class H1Config(RobotConfig):
+    """Config for the H1 robot."""
+
+    asset: MJCF = default(H1MJCF)
+    control: Control = default(Control(kp=20.0, kd=0.5))
+    state: H1State = default(H1State())
+
+    foot_name: list[str] = default(["foot"])
+    links_to_keep: list[str] = default([])
+    self_collisions: bool = True
+
+    def _create(self, scene: gs.Scene) -> RigidEntity:
+        return self.asset.create(
+            scene,
+            pos=self.state.pos,
+            quat=self.state.quat,
+            links_to_keep=self.links_to_keep,
+            collision=True,
+        )
+
+    def create(self, scene: gs.Scene) -> "H1Robot":
+        return H1Robot(scene, self)
+
+
+class H1Robot(Robot):
+    def __init__(self, scene: gs.Scene, cfg: H1Config):
+        super().__init__(scene, cfg)
+
+    @property
+    def action_space(self) -> spaces.Box:
+        j = len(self.cfg.state.joints)
+        return spaces.Box(low=-np.pi, high=np.pi, shape=(j,), dtype=np.float32)
+
+    @property
+    def observation_space(self) -> spaces.Dict:
+        def _float_inf(shape):
+            return spaces.Box(low=-np.inf, high=np.inf, shape=shape, dtype=np.float32)
+
+        return spaces.Dict(
+            {
+                "base_pos": _float_inf((3,)),
+                "base_quat": _float_inf((4,)),
+                "base_velo": _float_inf((3,)),
+                "base_ang": _float_inf((3,)),
+            }
+        )
+
+    def observe(self) -> Dict:
+        return {
+            "base": {
+                "pos": self.robot.get_pos(),
+                "quat": self.robot.get_quat(),
+                "inv_quat": self.inv_quat,
+                "vel": self.robot.get_vel(),
+                "ang": self.robot.get_ang(),
+            },
+            "dof": {
+                "pos": self.robot.get_dofs_position(self.dofs),
+                "vel": self.robot.get_dofs_velocity(self.dofs),
+            },
+        }
+

--- a/tag/gym/robots/robot.py
+++ b/tag/gym/robots/robot.py
@@ -2,8 +2,11 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 import itertools
 
+import genesis as gs
 from genesis.engine.entities.rigid_entity import RigidEntity
+from genesis.utils.geom import inv_quat
 from gymnasium import spaces
+import torch
 
 from tag.gym.base.config import Asset, Control, State
 from tag.protocols import Wraps, _Robot
@@ -22,6 +25,10 @@ class RobotConfig(ABC):
     asset: Asset = defaultcls(Asset)
     state: RobotState = defaultcls(RobotState)
     control: Control = defaultcls(Control)
+
+    @property
+    def dof_names(self) -> list[str]:
+        return list(getattr(self.state, "joints", {}).keys())
 
     def _create(self, scene) -> RigidEntity:
         """create robot asset"""
@@ -81,3 +88,56 @@ class Robot(_Robot, Wraps):
     @property
     def link_names(self):
         return [link.name for link in self.robot.links]
+
+    #
+    # Common robot helpers
+    #
+
+    @property
+    def wrapped(self) -> RigidEntity:
+        return self.robot
+
+    @property
+    def pos(self) -> torch.Tensor:
+        return torch.tensor(self.robot.get_pos(), device=gs.device, dtype=gs.tc_float)
+
+    @property
+    def quat(self) -> torch.Tensor:
+        return torch.tensor(self.robot.get_quat(), device=gs.device, dtype=gs.tc_float)
+
+    @property
+    def inv_quat(self) -> torch.Tensor:
+        return inv_quat(self.quat)
+
+    @property
+    def dofs(self) -> list[int]:
+        return sum(
+            [self.robot.get_joint(name).dofs_idx_local for name in self.cfg.dof_names],
+            [],
+        )
+
+    def act(self, action: torch.Tensor, mode: str = "position") -> None:
+        if mode == "position":
+            self.robot.control_dofs_position(position=action, dofs_idx_local=self.dofs)
+
+    def reset(self, envs_idx: list[int]) -> None:
+        b = len(envs_idx)
+        if b == 0:
+            return
+
+        def _tile(x):
+            return torch.tensor(x, device=gs.device).tile((b, 1))
+
+        kp = torch.tensor([self.cfg.control.kp] * len(self.dofs))
+        kd = torch.tensor([self.cfg.control.kd] * len(self.dofs))
+        self.robot.set_dofs_kp(kp, dofs_idx_local=self.dofs)
+        self.robot.set_dofs_kv(kd, dofs_idx_local=self.dofs)
+        self.robot.set_dofs_position(
+            position=_tile(list(self.cfg.state.joints.values())),
+            dofs_idx_local=self.dofs,
+            zero_velocity=True,
+            envs_idx=envs_idx,
+        )
+        self.robot.set_pos(_tile(self.cfg.state.pos), zero_velocity=False, envs_idx=envs_idx)
+        self.robot.set_quat(_tile(self.cfg.state.quat), zero_velocity=False, envs_idx=envs_idx)
+        self.robot.zero_all_dofs_velocity(envs_idx)


### PR DESCRIPTION
## Summary
- add config and robot class for Unitree H1
- export H1 classes
- refactor Robot base for reuse

## Testing
- `ruff check tag/gym/robots/__init__.py tag/gym/robots/h1.py tag/gym/robots/go2.py tag/gym/robots/robot.py`
- `pytest -q` *(fails: ModuleNotFoundError: genesis)*

------
https://chatgpt.com/codex/tasks/task_e_683b42a7ea28832996cad32d8f1f7117